### PR TITLE
add uninstall.sh

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,1 @@
+rm -rf /data/adb/zapret


### PR DESCRIPTION
Удаляет папку /data/adb/zapret при удалении модуля